### PR TITLE
MNT (2) Reimplemented high level using asarray().

### DIFF
--- a/docs/src/manual/common-api.md
+++ b/docs/src/manual/common-api.md
@@ -1,6 +1,6 @@
 # [Common API](@id man-common-api)
 
 ```@docs
-JuQ.K_Object
+JuQ.KdbException
 JuQ._E
 ```

--- a/src/JuQ.jl
+++ b/src/JuQ.jl
@@ -6,31 +6,23 @@ include("_k.jl")
 using Base.Dates.AbstractTime
 using JuQ._k
 
+"""
+    KdbException(s)
+
+A call to kdb resulted in an error. Argument `s` is a descriptive error string
+reported by kdb.
+"""
 struct KdbException <: Exception
     s::String
 end
-
-#########################################################################
-# Wrapper around q's C K type, with hooks to q reference
-# counting and conversion routines to/from C and Julia types.
-
-"A K object reference managed by Julia GC."
-mutable struct K_Object
-    x::K_ # pointer to the actual K object
-    function K_Object(x::K_)
-        @assert x != 0
-        o = new(x)
-        finalizer(o, o->r0(o.x))
-        return o
-    end
-end
+# Supertypes for atomic q types.
 const SUPERTYPE = Dict(
-    :_Bool=>Integer,
-    :_Unsigned=>Unsigned,
-    :_Signed=>Signed,
-    :_Float=>AbstractFloat,
-    :_Text=>Any,
-    :_Temporal=>AbstractTime
+    :_Bool     => Integer,
+    :_Unsigned => Unsigned,
+    :_Signed   => Signed,
+    :_Float    => AbstractFloat,
+    :_Text     => Any,
+    :_Temporal => AbstractTime
 )
 K_CLASSES = Type[]
 # Create a parametrized type for each type class.
@@ -38,20 +30,20 @@ for (class, super) in SUPERTYPE
     @eval begin
         export $(class)
         struct $(class){t,CT,JT} <: $(super)
-            o::K_Object
+            a::Array{CT,0}
             function $(class){t,CT,JT}(x::K_) where {t,CT,JT}
-                o = K_Object(x)
+                a = asarray(x)
                 t′ = xt(x)
                 if t != -t′
                     throw(ArgumentError("type mismatch: t=$t, t′=$t′"))
                 end
-                new(o)
+                new(a)
             end
         end
         function Base.convert(::Type{$(class){t,CT,JT}}, x) where {t,CT,JT}
-            p = ka(-t)
-            unsafe_store!(Ptr{CT}(p+8), _cast(CT, JT(x))::CT)
-            $(class){t,CT,JT}(p)
+            r = $(class){t,CT,JT}(ka(-t))
+            r.a[] = _cast(CT, JT(x))::CT
+            r
         end
         push!(K_CLASSES, $(class))
         Base.size(::$(class)) = ()
@@ -63,14 +55,9 @@ for (class, super) in SUPERTYPE
         Base.endof(x::$(class)) = 1
         # payload
         Base.eltype(x::$(class){t,CT,JT}) where {t,CT,JT} = JT
-        Base.pointer(x::$(class){t,CT,JT}) where {t,CT,JT} = Ptr{CT}(x.o.x+8)
-        load(x::$(class){t,CT,JT}) where {t,CT,JT} = unsafe_load(pointer(x))
-        _get(x::$(class){t,CT,JT}) where {t,CT,JT} = _cast(JT, load(x))
-        store!(x::$(class){t,CT,JT}, y::CT) where {t,CT,JT} =
-            (unsafe_store!(pointer(x), y); x)
-        _set!(x::$(class){t,CT,JT}, y) where {t,CT,JT} =
-            (store!(x, _cast(CT, convert(JT, y))); x)
-        Base.show(io::IO, x::$class) = print(io, "K(", repr(_get(x)), ")")
+        Base.pointer(x::$(class){t,CT,JT}) where {t,CT,JT} = pointer(x.a)
+        Base.show(io::IO, x::$(class){t,CT,JT}) where {t,CT,JT} = print(io,
+            "K(", repr(JT(x.a[])), ")")
     end
 end
 @eval const K_Scalar = Union{$(K_CLASSES...)}
@@ -80,138 +67,149 @@ K_CLASS = Dict{Int8,Type}()
 for ti in TYPE_INFO
     ktype = Symbol("K_", ti.name)
     class = ti.class
+    T = ti.jl_type
     @eval begin
         export $(ktype)
         global const $(ktype) =
-              $(class){$(ti.number),$(ti.c_type),$(ti.jl_type)}
+              $(class){$(ti.number),$(ti.c_type),$T}
         K_CLASS[$(ti.number)] = $(class)
         # Display type aliases by name in REPL.
         Base.show(io::IO, ::Type{$(ktype)}) = print(io, $(string(ktype)))
         # Conversion to Julia types
-        Base.convert(::Type{$(ti.jl_type)}, x::$(ktype)) = _get(x)
-        Base.promote_rule(x::Type{$(ti.jl_type)},
-                          y::Type{$(ktype)}) = x
+        Base.convert(::Type{$T}, x::$(ktype)) = _cast($T, x.a[])
+        Base.promote_rule(x::Type{$T}, y::Type{$(ktype)}) = x
         # Disambiguate T -> K type conversions
         Base.convert(::Type{$ktype}, x::$ktype) = x
-        # Display and printing
     end
     if ti.class in [:_Signed, :_Integer]
         @eval Base.dec(x::$(ktype), pad::Int=1) =
-            string(dec(load(x), pad), $(ti.letter))
+            string(dec(x.a[], pad), $(ti.letter))
     elseif ti.class === :_Unsigned
         @eval Base.hex(x::$(ktype), pad::Int=1, neg::Bool=false) =
-            hex(load(x), pad, neg)
+            hex(x.a[], pad, neg)
     end
 end
 function K_Scalar(x::K_)
     t = -xt(x)
     ti = typeinfo(t)
-    class = K_CLASS[t]
-    return class{t,ti.c_type,ti.jl_type}(x)
+    K_CLASS[t]{t,ti.c_type,ti.jl_type}(x)
 end
 include("promote_rules.jl")
-struct K_Other
-    o::K_Object
-    function K_Other(o::K_Object)
-        return new(o)
-    end
+struct K_Lambda
+    a::Vector{K_}
+    K_Lambda(x::K_) = new(asarray(x))
 end
-struct K_Vector{t,CT,JT} <: AbstractVector{JT}
-    o::K_Object
-    function K_Vector{t,CT,JT}(o::K_Object) where {t,CT,JT}
-        t′ = xt(o.x)
-        if(t != t′)
+struct K_Other
+    a::Array{T,0} where T
+    K_Other(x::K_) = new(asarray(x))
+end
+struct K_Vector{t,C,T} <: AbstractVector{T}
+    a::Vector{C}
+    function K_Vector{t,C,T}(x::K_) where {t,C,T}
+        a = asarray(x)
+        t′ = xt(x)
+        if t != t′
             throw(ArgumentError("type mismatch: t=$t, t′=$t′"))
         end
-        return new{t,CT,JT}(o)
+        return new(a)
     end
 end
-K_Chars = K_Vector{KC,C_,Char}
-function K_Vector(o::K_Object)
-    t = xt(o.x)
-    CT = C_TYPE[t]
-    JT = JULIA_TYPE[t]
-    K_Vector{t,CT,JT}(o)
+const K_Chars = K_Vector{KC,C_,Char}
+function K_Vector(x::K_)
+    t = xt(x)
+    ti = typeinfo(t)
+    K_Vector{t,ti.c_type,ti.jl_type}(x)
 end
-_cast(::Type{T}, x::T) where T = x
-_cast(::Type{JT}, x::CT) where {JT,CT} = JT(x)
-_cast(::Type{Symbol}, x::S_) = Symbol(unsafe_string(x))
 
 Symbol(x::K_symbol) = convert(Symbol, x)
 K_Vector(a::Vector) = K_Vector(K(a))
 
-Base.eltype(v::K_Vector{t,CT,JT}) where {t,CT,JT} = JT
-Base.size(v::K_Vector{t,CT,JT}) where {t,CT,JT} = (convert(Int, xn(v.o.x)),)
-function Base.getindex(v::K_Vector{t,CT,JT}, i::Integer) where {t,CT,JT}
-    @boundscheck checkbounds(v, i)
-    _cast(JT, unsafe_load(Ptr{CT}(v.o.x + 16), i)::CT)
+Base.eltype(v::K_Vector{t,C,T}) where {t,C,T} = T
+Base.size(v::K_Vector{t,C,T}) where {t,C,T} = size(v.a)
+Base.getindex(v::K_Vector{t,C,T}, i::Integer) where {t,C,T} = _cast(T, v.a[i])
+# Setting the vector elements
+Base.setindex!(v::K_Vector{t,C,T}, el, i::Integer) where {t,C,T} = begin
+    v.a[i] = _cast(C, T(el))
+    v
 end
+
+# See julia.h.
+struct jl_array_t
+    data   :: Ptr{Void} # (1)  sizeof(Ptr)
+    length :: Csize_t   # (2) + sizeof(Ptr)
+    flags  :: UInt16    # (3) + 2 bytes
+    elsize :: UInt16    # (4) + 2 bytes
+    offset :: UInt32    # (5) + 4 bytes
+    nrows  :: Csize_t   # (6) = at 2*sizeof(Ptr) + 8
+    maxsize:: Csize_t   # (7)
+end
+
+const offset_length = fieldoffset(jl_array_t, 2)
+const offset_nrows = fieldoffset(jl_array_t, 6)
+# Extending vectors (☡)
+function Base.push!(x::K_Vector{t,C,T}, y) where {t,C,T}
+    n′ = length(x) + 1
+    a = _cast(C, T(y))
+    p = K_(pointer(x)-16)
+    p′ = ja(Ref{K_}(p), Ref(a))
+    ptr_xa = Ptr{jl_array_t}(pointer_from_objref(x.a))
+    # Pre-checks
+    d = unsafe_load(ptr_xa)
+    @assert d.data == pointer(x)
+    @assert d.length == d.nrows == n′ - 1
+    # replant the data pointer
+    unsafe_store!(Ptr{Ptr{Void}}(ptr_xa), p′+16)
+    # update the size
+    unsafe_store!(Ptr{Csize_t}(ptr_xa + offset_length), n′)
+    unsafe_store!(Ptr{Csize_t}(ptr_xa + offset_nrows), n′)
+    # Post-checks
+    d = unsafe_load(ptr_xa)
+    @assert d.data == pointer(x)
+    @assert d.length == d.nrows == n′
+    x
+end
+
 include("table.jl")
 
-Base.:(==)(x::K_Scalar, y::K_Scalar) = load(x) == load(y)
-Base.isless(x::K_Scalar, y::K_Scalar) = load(x) < load(y)
-const K = Union{K_Vector,K_Table,K_Other,K_Scalar}
-Base.show(io::IO, ::Type{K}) = write(io, "K")
-_cast(::Type{K}, x::K_) = K(x == C_NULL ? x : r1(x))
-_cast(::Type{K_}, x::K) = (x = x.o.x; x == C_NULL ? x : r1(x))
+Base.:(==)(x::K_Scalar, y::K_Scalar) = x.a == y.a
+Base.isless(x::K_Scalar, y::K_Scalar) = x.a[] < y.a[]
 
-const JULIA_TYPE = merge(
-    Dict(KK=>K),
-    Dict(ti.number=>ti.jl_type for ti in TYPE_INFO))
+kpointer(x::Union{K_Scalar,K_Other}) = K_(pointer(x.a)-8)
+kpointer(x::Union{K_Vector,K_Lambda,K_guid}) = K_(pointer(x.a)-16)
+
+const K = Union{K_Scalar,K_Vector,K_Table,K_Lambda,K_Other}
+# TODO: Consider moving all K_new methods here.
+_k.K_new(x::K) = r1(kpointer(x))
+const TI0 = TI(0, 'k', "any", K_, K, :NA)
+typeinfo(t::Integer) = t == 0 ? TI0 : TYPE_INFO[t - (t>2)]
+# Conversions between C and Julia types
+_cast(::Type{T}, x::T) where T = x
+_cast(::Type{T}, x::C) where {T,C} = T(x)
+_cast(::Type{Symbol}, x::S_) = Symbol(unsafe_string(x))
+_cast(::Type{K}, x::K_) = K(r1(x))
+_cast(::Type{K_}, x::K) = r1(kpointer(x))
+
+# TODO: replace K_Vector with K below once asarray() transition is complete.
+Base.pointer(x::K_Vector, i::Integer=1) = pointer(x.a, i)
+Base.show(io::IO, ::Type{K}) = write(io, "K")
 
 include("conversions.jl")
 
-# Setting the vector elements
-import Base.pointer, Base.fill!, Base.copy!, Base.setindex!
-pointer(x::K_Vector{t,CT,JT}, i::Integer=1) where {t,CT,JT} =
-    Ptr{CT}(x.o.x+15+i)
-function fill!(x::K_Vector{t,CT,JT}, el::JT) where {t,CT,JT}
-    n = xn(x.o.x)
-    p = pointer(x)
-    el = _cast(CT, el)
-    for i in 1:n
-        unsafe_store!(p, el, i)
-    end
-    x
-end
-function setindex!(x::K_Vector{t,CT,JT}, el, i::Int) where {t,CT,JT}
-    @boundscheck checkbounds(x, i)
-    p = pointer(x)
-    el = _cast(CT, convert(JT, el)::JT)
-    unsafe_store!(p, el, i)
-    x
-end
-
 # K[...] constructors
-
 Base.getindex(::Type{K}) = K(ktn(0,0))
 function Base.getindex(::Type{K}, v)
     t = K_TYPE[typeof(v)]
-    x = ktn(t, 1)
-    T = eltype(x)
-    v = _cast(T, v)
-    copy!(x, [v])
-    K(x)
+    r = K(ktn(t, 1))
+    r.a[1] = _cast(eltype(r), v)
+    r
 end
 function Base.getindex(::Type{K}, v...)
     n = length(v)
     t = get(K_TYPE, Base.promote_typeof(v...), KK)
-    if t > KK  # k vector
-        x = ktn(t, n)
-        T = eltype(x)
-        v = map(e->_cast(T, e), collect(v))
-        copy!(x, v)
-    else       # k list
-        x = ktn(0, n)
-        copy!(x, map(K_new, v))
-    end
-    K(x)
-end
-
-function Base.push!(x::K_Vector{t,C,T}, y) where {t,C,T}
-    a = _cast(C, T(y))
-    ja(Ref{K_}(x.o.x), Ref{C}(a))
-    x
+    r = K(ktn(t, n))
+    C, T = map(eltype, (r.a, r))
+    copy!(r.a, map(e->_cast(C, T(e)), v))
+    r
 end
 
 if GOT_Q

--- a/src/_k.jl
+++ b/src/_k.jl
@@ -19,7 +19,7 @@ export B_, C_, S_, G_, H_, I_, J_, E_, F_, V_, U_, K_, C_TYPE, K_TYPE
 export KB, UU, KG, KH, KI, KJ, KE, KF, KC, KS, KP, KM, KD, KN, KU, KV, KT,
        XT, XD, KK, EE
 export K_new
-export TYPE_INFO, TYPE_CLASSES, typeinfo
+export TYPE_INFO, TYPE_CLASSES, TI
 export asarray
 
 include("startup.jl")
@@ -60,7 +60,7 @@ const EE = I_(128)  #   error
 
 Base.show(io::IO, ::Type{K_}) = write(io, "K_")
 
-struct ∫
+struct TI
     number::C_
     letter::Char
     name::String
@@ -71,50 +71,36 @@ end
 
 const TYPE_INFO = [
     # num ltr name c_type jl_type super
-    ∫(1, 'b', "boolean", B_, Bool, :_Bool),
+    TI(1, 'b', "boolean", B_, Bool, :_Bool),
 
-    ∫(2, 'g', "guid", U_, UInt128, :_Unsigned),
-    ∫(4, 'x', "byte", G_, UInt8, :_Unsigned),
+    TI(2, 'g', "guid", U_, UInt128, :_Unsigned),
+    TI(4, 'x', "byte", G_, UInt8, :_Unsigned),
 
-    ∫(5, 'h', "short", H_, Int16, :_Signed),
-    ∫(6, 'i', "int", I_, Int32, :_Signed),
-    ∫(7, 'j', "long", J_, Int64, :_Signed),
+    TI(5, 'h', "short", H_, Int16, :_Signed),
+    TI(6, 'i', "int", I_, Int32, :_Signed),
+    TI(7, 'j', "long", J_, Int64, :_Signed),
 
-    ∫(8, 'e', "real", E_, Float32, :_Float),
-    ∫(9, 'f', "float", F_, Float64, :_Float),
+    TI(8, 'e', "real", E_, Float32, :_Float),
+    TI(9, 'f', "float", F_, Float64, :_Float),
 
-    ∫(10, 'c', "char", C_, Char, :_Text),
-    ∫(11, 's', "symbol", S_, Symbol, :_Text),
+    TI(10, 'c', "char", C_, Char, :_Text),
+    TI(11, 's', "symbol", S_, Symbol, :_Text),
 
-    ∫(12, 'p', "timestamp", J_, Int64, :_Temporal),
-    ∫(13, 'm', "month", I_, Int32, :_Temporal),
-    ∫(14, 'd', "date", I_, Int32, :_Temporal),
-    ∫(15, 'z', "datetime", I_, Int32, :_Temporal),
-    ∫(16, 'n', "timespan", J_, Int64, :_Temporal),
-    ∫(17, 'u', "minute", I_, Int32, :_Temporal),
-    ∫(18, 'v', "second", I_, Int32, :_Temporal),
-    ∫(19, 't', "time", I_, Int32, :_Temporal),
+    TI(12, 'p', "timestamp", J_, Int64, :_Temporal),
+    TI(13, 'm', "month", I_, Int32, :_Temporal),
+    TI(14, 'd', "date", I_, Int32, :_Temporal),
+    TI(15, 'z', "datetime", I_, Int32, :_Temporal),
+    TI(16, 'n', "timespan", J_, Int64, :_Temporal),
+    TI(17, 'u', "minute", I_, Int32, :_Temporal),
+    TI(18, 'v', "second", I_, Int32, :_Temporal),
+    TI(19, 't', "time", I_, Int32, :_Temporal),
 ]
-typeinfo(t::Integer) = (if t > 2; t -= 1 end; TYPE_INFO[t])
-_offset1(t::Integer) = (-2 ≠ t < 0 ? 7 : 15)  # 1-based
-_offset1(x::K_) = x |> t |> _offset1
 const TYPE_CLASSES = unique(t.class for t in TYPE_INFO)
 const C_TYPE = merge(
     Dict(KK=>K_, EE=>S_, XT=>K_, XD=>K_, (-EE)=>S_,  # XXX: do we need both ±EE?
          100=>K_, 101=>I_, 102=>I_, 103=>I_, 104=>K_, 105=>K_,
          106=>K_, 107=>K_, 108=>K_, 109=>K_, 110=>K_, 111=>K_, 112=>V_),
     Dict(t.number=>t.c_type for t in TYPE_INFO))
-function ctype(t)
-    if t < 0
-        return C_TYPE[-t]
-    elseif t <= KT || t >= XD
-        return C_TYPE[t]
-    elseif t < 77  # enums
-        return I_
-    else
-        return J_  # nested
-    end
-end
 # returns type, offset and size
 function cinfo(x::K_)
     h = unsafe_load(x)
@@ -300,41 +286,6 @@ k(h::Integer, m::String, x1::K_, x2::K_, x3::K_, x4::K_, x5::K_, x6::K_,
     x7::K_, x8::K_) =
         ccall((@k_sym :k), K_, (I_, S_, K_, K_, K_, K_, K_, K_, K_, K_, K_),
                 h, m, x1, x2, x3, x4, x5, x6, x7, x8, K_NULL)
-# Iterator protocol
-import Base.start, Base.next, Base.done, Base.length, Base.eltype
-struct _State{T} ptr::Ptr{T}; stop::Ptr{T}; stride::J_ end
-eltype(x::K_) = ctype(xt(x))
-function start(x::K_)
-    T = eltype(x)
-    ptr = Ptr{T}(x+16)
-    stride = sizeof(T)
-    stop = ptr + xn(x)*stride
-    return _State{T}(ptr, stop, stride)
-end
-next(x, s) = (unsafe_load(s.ptr), _State(s.ptr + s.stride, s.stop, s.stride))
-done(x, s) = s.ptr == s.stop
-length(x) = xn(x)
-
-# Filling the elements
-import Base.pointer, Base.fill!, Base.copy!
-pointer(x::K_, i=1::Integer) = (T=eltype(x); Ptr{T}(x+_offset1(x)+i))
-function fill!(x::K_, el)
-    n = xn(x)
-    p = pointer(x)
-    T = typeof(p).parameters[1]
-    f = (T === K_ ? r1 : identity)
-    for i in 1:n
-        unsafe_store!(p, T(f(el))::T, i)
-    end
-end
-function copy!(x::K_, iter)
-    p = pointer(x)
-    T = typeof(p).parameters[1]
-    f = (T === K_ ? r1 : identity)
-    for (i, el::T) in enumerate(iter)
-        unsafe_store!(p, f(el), i)
-    end
-end
 
 ## New reference
 K_new(x::K_) = r1(x)

--- a/src/q.jl
+++ b/src/q.jl
@@ -1,15 +1,15 @@
 export @q_cmd
+# TODO: Use dot_ here.
+_apply(f, args...) = K(k(0, ".", K_new(f), K_new(args)))
+(f::K_Lambda)() = f(nothing)
+(f::K_Other)() = f(nothing)
+(f::K_Lambda)(args...) = _apply(f, args...)
+(f::K_Other)(args...) = _apply(f, args...)
 
-(f::JuQ.K_Other)() = f(nothing)
-function (f::JuQ.K_Other)(args...)
-   p = k(0, ".", K_new(f.o.x), K_new(args))
-   K(p)
-end
-
-const Q_PARSE = "{\$[0=t:type e:parse x;{y;eval x}e;t=-11;eval e;e]}" 
+const Q_PARSE = "{\$[0=t:type e:parse x;{y;eval x}e;t=-11;eval e;e]}"
 macro q_cmd(s) _E(k(0, Q_PARSE, kp(s))) end
 function Base.show(io::IO, x::K)
-    s = k(0, "{` sv .Q.S[40 80;0;x]}", r1(x.o.x))
+    s = k(0, "{` sv .Q.S[40 80;0;x]}", K_new(x))
     try
         write(io, strip(unsafe_string(pointer(s), xn(s))))
     finally

--- a/src/table.jl
+++ b/src/table.jl
@@ -1,22 +1,21 @@
 using DataFrames
 
 struct K_Table  <: AbstractDataFrame
-    o::K_Object
+    a::Array{K_,0}
     function K_Table(x::K_)
-        o = K_Object(x)
+        a = asarray(x)
         t = xt(x)
         if(t != XT)
             throw(ArgumentError("type mismatch: t=$t ≠ $XT"))
         end
-        return new(o)
+        return new(a)
     end
     function K_Table(columns::Vector, colnames::Vector{Symbol})
         ncols = length(columns)
-        x = K(colnames)
-        kcols = map(x->r1(K(x).o.x), columns)
-        y = knk(ncols, kcols...)
-        o = K_Object(xT(xD(r1(x.o.x), y)))
-        new(o)
+        x = K_new(colnames)
+        y = K_new(columns)
+        a = asarray(xT(xD(x, y)))
+        new(a)
     end
     function K_Table(; kwargs...)
         x = ktn(KS, 0)
@@ -26,16 +25,16 @@ struct K_Table  <: AbstractDataFrame
             x = js(rx, ss(k))
             y = jk(ry, K_new(v))
         end
-        o = K_Object(xT(xD(x, y)))
-        new(o)
+        a = asarray(xT(xD(x, y)))
+        new(a)
     end
 end
 
-DataFrames.ncol(x::K_Table) = xn(xx(xk(x.o.x)))
-DataFrames.nrow(x::K_Table) = xn(unsafe_load(Ptr{K_}(xy(xk(x.o.x))+16)))
-DataFrames.index(x::K_Table) = DataFrames.Index(Array(K(xx(xk(x.o.x)))))
-DataFrames.columns(x::K_Table) = K(xx(xk(x.o.x)))
-cols(x::K_Table) = K(xx(xk(x.o.x)))
+DataFrames.ncol(x::K_Table) = xn(xx(x.a[]))
+DataFrames.nrow(x::K_Table) = xn(unsafe_load(Ptr{K_}(xy(x.a[])+16)))
+DataFrames.index(x::K_Table) = DataFrames.Index(Array(K(xx(x.a[]))))
+DataFrames.columns(x::K_Table) = K(xx(x.a[]))
+cols(x::K_Table) = K(xx(x.a[]))
 Base.getindex(x::K_Table, i::Integer) =
-    K(r1(unsafe_load(Ptr{K_}(xy(xk(x.o.x))+16), i)))
+    K(r1(unsafe_load(Ptr{K_}(xy(x.a[])+16), i)))
 Base.getindex(x::K_Table, i::Integer, j::Integer) = x[j][i]

--- a/test/server-tests.jl
+++ b/test/server-tests.jl
@@ -1,5 +1,5 @@
 qa(cmd) = asarray(k(0, cmd))
-qa(cmd, x...) = asarray(k(0, cmd), map(K_new, x)...)
+qa(cmd, x...) = asarray(k(0, cmd, map(K_new, x)...))
 @testset "server-side low level" begin
   @test begin  # dot_
     f = k(0, "til")
@@ -14,6 +14,17 @@ qa(cmd, x...) = asarray(k(0, cmd), map(K_new, x)...)
     x = knk(1, kc(99)) # ,"c"
     ax = asarray(x)    # ensure r0
     unsafe_string(asarray(ee(dot_(f, x)))[]) == "type"
+  end
+  @testset "msg to handle 0" begin
+    # using k(0, ..)
+    @test qa("{x}", 1)[] == 1
+    @test qa("{y}", 1, 2)[] == 2
+    @test qa("{z}", 1, 2, 3)[] == 3
+    @test qa("{[a;b;c;d]d}", 1, 2, 3, 4)[] == 4
+    @test qa("{[a;b;c;d;e]e}", 1, 2, 3, 4, 5)[] == 5
+    @test qa("{[a;b;c;d;e;f]f}", 1, 2, 3, 4, 5, 6)[] == 6
+    @test qa("{[a;b;c;d;e;f;g]g}", 1, 2, 3, 4, 5, 6, 7)[] == 7
+    @test qa("{[a;b;c;d;e;f;g;h]h}", 1, 2, 3, 4, 5, 6, 7, 8)[] == 8
   end
 end
 @testset "server-side asarray" begin
@@ -57,5 +68,16 @@ end
     @test (x = e("Int64(1)"); eltype(x) == Int64 && x == 1)
     @test (x = e("1.5"); eltype(x) == Float64 && x == 1.5)
     @test (x = e("Float32(1)"); eltype(x) == Float32 && x == 1)
+  end
+  @testset "q function calls" begin
+    # using q``
+    @test q`{x}`(1) == 1
+    @test q`{y}`(1, 2) == 2
+    @test q`{z}`(1, 2, 3) == 3
+    @test q`{[a;b;c;d]d}`(1, 2, 3, 4) == 4
+    @test q`{[a;b;c;d;e]e}`(1, 2, 3, 4, 5) == 5
+    @test q`{[a;b;c;d;e;f]f}`(1, 2, 3, 4, 5, 6) == 6
+    @test q`{[a;b;c;d;e;f;g]g}`(1, 2, 3, 4, 5, 6, 7) == 7
+    @test q`{[a;b;c;d;e;f;g;h]h}`(1, 2, 3, 4, 5, 6, 7, 8) == 8
   end
 end

--- a/test/show-coverage.jl
+++ b/test/show-coverage.jl
@@ -1,0 +1,8 @@
+using Coverage
+# defaults to src/; alternatively, supply the folder name as argument
+coverage = process_folder()
+# Get total coverage for all Julia files
+covered_lines, total_lines = get_summary(coverage)
+# Or process a single file
+@show get_summary(process_file("src/JuQ.jl"))
+@show get_summary(process_file("src/_k.jl"))


### PR DESCRIPTION
MNT Reimplemented vectors using asarray().

MNT Reimplemented K_Table using asarray().

DOC Documented KdbException.

MNT Reimplemented K_Other to use asarray().

MNT Removed unused code.

TST Fixed qa(cmd, x...).

ENH Implemented K_new(K).

ENH Introduced K_Lambda to represent composite callables.

K_Lambda is used to represent q lambdas (t=100), projections
(t=104) and compositions (t=105).

ENH Defined conversion from K_real to Float64.

MNT Rewrote push! using struct definition and fieldoffset().

DOC Removed K_Object from docs.

 - added KdbException

MNT Removed unused code.

MNT Removed low level iteration in favor of asarray().

TST Simplified tests.

TST Added server-side tests.

MNT Removed unused code.

TST Added a script to process coverage.