### PR TITLE
MNT Do not use a large Union to define K type.

### DIFF
--- a/src/JuQ.jl
+++ b/src/JuQ.jl
@@ -5,7 +5,22 @@ export KdbException
 include("_k.jl")
 using Base.Dates.AbstractTime
 using JuQ._k
+"""
+    K(x)
 
+Construct a kdb+ object.
+"""
+abstract type K end
+K(x) = convert(K, x)  # allow non-K return types
+"""
+    kpointer(x)
+
+A memory address referring to a kdb+ object.
+"""
+kpointer
+
+Base.convert(::Type{K_}, x) = r1(kpointer(x))
+_k.K_new(x) = r1(kpointer(x))
 """
     KdbException(s)
 
@@ -42,7 +57,7 @@ Base.isless(x::K_Atom, y::K_Atom) = x.a[] < y.a[]
 kpointer(x::Union{K_Atom,K_Other}) = K_(pointer(x.a)-8)
 kpointer(x::Union{K_Vector,K_Lambda,K_guid}) = K_(pointer(x.a)-16)
 
-const K = Union{K_Atom,K_Vector,K_Table,K_Lambda,K_Other}
+#const K = Union{K_Atom,K_Vector,K_Table,K_Lambda,K_Other}
 # TODO: Consider moving all K_new methods here.
 _k.K_new(x::K) = r1(kpointer(x))
 const TI0 = TI(0, 'k', "any", K_, K, :NA)
@@ -55,7 +70,7 @@ _cast(::Type{T}, x::T) where T = x
 _cast(::Type{T}, x::C) where {T,C} = T(x)
 _cast(::Type{Symbol}, x::S_) = Symbol(unsafe_string(x))
 _cast(::Type{K}, x::K_) = K(r1(x))
-_cast(::Type{K_}, x::K) = r1(kpointer(x))
+#_cast(::Type{K_}, x::K) = r1(kpointer(x))
 
 # TODO: replace K_Vector with K below once asarray() transition is complete.
 Base.pointer(x::K_Vector, i::Integer=1) = pointer(x.a, i)

--- a/src/_k.jl
+++ b/src/_k.jl
@@ -348,6 +348,10 @@ function asarray(x::K_, own::Bool=true)
     end
     a
 end
-
+Base.convert(::Type{Array}, x::K_) = asarray(x)
+using Core.Intrinsics.bitcast
+Base.convert(::Type{K_}, p::K_) = p
+Base.convert(::Type{K_}, p::Ptr) = bitcast(K_, p)
+Base.convert(::Type{K_}, p::UInt) = bitcast(K_, p)
 
 end # module k

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -46,7 +46,7 @@ function Base.convert(::Type{K}, x::K_)
     return K_Other(x)
 end
 Base.convert(::Type{K}, x::K) = x
-Base.convert(::Type{K}, x) = K(K_new(x))
+Base.convert(::Type{K}, x) = convert(K, K_new(x))
 
 Base.print(io::IO, x::K_boolean) = print(io, Bool(x) ? "1b" : "0b")
 Base.show(io::IO, x::K_boolean) = print(io, x)

--- a/src/q.jl
+++ b/src/q.jl
@@ -2,10 +2,10 @@ export @q_cmd
 
 
 function kerror()
-    e = asarray(ee(K_(0)))
+    e = asarray(ee(K_(C_NULL)))
     unsafe_string(e[])
 end
-function apply(f::K, args...)
+function apply(f, args...)
     x = K(args)
     r = dot_(kpointer(f), kpointer(x))
     if r == C_NULL


### PR DESCRIPTION
Defining `K` as 

```julia
const K = Union{K_Atom,K_Vector,K_Table,K_Lambda,K_Other}
```

resulted in very long compile times for expressions like `K[]`.  In this PR, we redefine `K` as an abstract type.